### PR TITLE
go.mod: require correct version of k8s.io/client-go directly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ require (
 	github.com/stretchr/testify v1.5.1
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2
-	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/client-go v0.18.2
 	sigs.k8s.io/controller-runtime v0.6.0
 )
-
-replace k8s.io/client-go => k8s.io/client-go v0.18.2


### PR DESCRIPTION
No need to require an old version of `k8s.io/client-go` and then `replace` it. In fact, it _really_ hurts our users, because they would be forced to do the same thing in any modules that depend on this one.