### PR TITLE
predicate/nogeneration.go: add `NoGenerationPredicate`

### DIFF
--- a/predicate/nogeneration.go
+++ b/predicate/nogeneration.go
@@ -1,0 +1,81 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var _ predicate.Predicate = NoGenerationPredicate{}
+
+// NoGenerationPredicate implements a update predicate function for objects with no Generation value, like a Pod.
+//
+// This predicate will allow update events on objects that never have their metadata.generation field updated
+// by the system, i.e. do not respect Generation semantics:
+// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+// This allows a controller to update objects that may have had their spec changed but, because the object does
+// not use a generation, will inform on that change in some other manner.
+//
+// This predicate can be useful by itself, but is intended to be used in conjunction with
+// sigs.k8s.io/controller-runtime/pkg/predicate.GenerationChangedPredicate to allow update events on all potentially
+// changed objects, those that respect Generation semantics or those that do not:
+//
+//		import (
+//			corev1 "k8s.io/api/core/v1"
+//			appsv1 "k8s.io/api/apps/v1"
+//			ctrl "sigs.k8s.io/controller-runtime"
+//			"sigs.k8s.io/controller-runtime/pkg/event"
+//			ctrlpredicate "sigs.k8s.io/controller-runtime/pkg/predicate"
+//			libpredicate "github.com/operator-framework/operator-lib/predicate"
+//
+//			"github.com/example/my-operator/api/v1alpha1"
+//		)
+//
+//		func (r *MyTypeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+//			return ctrl.NewControllerManagedBy(mgr).
+//				For(&v1alpha1.MyType{}).
+//				Owns(&corev1.Pod{}).				// Does not respect Generation.
+//				Owns(&appsv1.Deployment{}).	// Respects Generation.
+//				WithEventFilter(ctrlpredicate.Or(ctrlpredicate.GenerationChangedPredicate{}, libpredicate.NoGenerationPredicate{})).
+//				Complete(r)
+//		}
+//
+type NoGenerationPredicate struct {
+	predicate.Funcs
+}
+
+// Update implements the default UpdateEvent filter for validating absence Generation.
+func (NoGenerationPredicate) Update(e event.UpdateEvent) bool {
+	if e.MetaOld == nil {
+		log.V(1).Info("Update event has no old metadata", "event", e)
+		return false
+	}
+	if e.ObjectOld == nil {
+		log.V(1).Info("Update event has no old runtime object to update", "event", e)
+		return false
+	}
+	if e.ObjectNew == nil {
+		log.V(1).Info("Update event has no new runtime object for update", "event", e)
+		return false
+	}
+	if e.MetaNew == nil {
+		log.V(1).Info("Update event has no new metadata", "event", e)
+		return false
+	}
+	// Since generation is monotonically increasing, the new generation will always be greater than the old
+	// iff the object respects generations.
+	return e.MetaNew.GetGeneration() == e.MetaOld.GetGeneration() && e.MetaNew.GetGeneration() == 0
+}

--- a/predicate/nogeneration_test.go
+++ b/predicate/nogeneration_test.go
@@ -1,0 +1,97 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var _ = Describe("NoGenerationPredicate", func() {
+	var (
+		e    event.UpdateEvent
+		pred NoGenerationPredicate
+	)
+
+	It("returns true", func() {
+		By("both the old and new objects having a generation of 0", func() {
+			e = makeEventFor(&corev1.Pod{}, &corev1.Pod{})
+			Expect(pred.Update(e)).To(BeTrue())
+		})
+	})
+
+	It("returns false", func() {
+		By("the new object having a non-zero generation", func() {
+			old, new := &appsv1.Deployment{}, &appsv1.Deployment{}
+			new.SetGeneration(1)
+			e = makeEventFor(old, new)
+			Expect(pred.Update(e)).To(BeFalse())
+		})
+		// The old generation will never be lower than the new, so we don't have to test that case.
+		By("the old and new objects having equal non-zero generations", func() {
+			old, new := &appsv1.Deployment{}, &appsv1.Deployment{}
+			old.SetGeneration(1)
+			new.SetGeneration(1)
+			e = makeEventFor(old, new)
+			Expect(pred.Update(e)).To(BeFalse())
+		})
+		By("the old and new objects having unequal non-zero generations", func() {
+			old, new := &appsv1.Deployment{}, &appsv1.Deployment{}
+			old.SetGeneration(1)
+			new.SetGeneration(2)
+			e = makeEventFor(old, new)
+			Expect(pred.Update(e)).To(BeFalse())
+		})
+	})
+
+	It("logs a message and returns false", func() {
+		By("the old object being nil", func() {
+			old, new := &appsv1.Deployment{}, &appsv1.Deployment{}
+			e = makeEventFor(old, new)
+			e.ObjectOld = nil
+			Expect(pred.Update(e)).To(BeFalse())
+		})
+		By("the old metadata being nil", func() {
+			old, new := &appsv1.Deployment{}, &appsv1.Deployment{}
+			e = makeEventFor(old, new)
+			e.MetaOld = nil
+			Expect(pred.Update(e)).To(BeFalse())
+		})
+		By("the new object being nil", func() {
+			old, new := &appsv1.Deployment{}, &appsv1.Deployment{}
+			e = makeEventFor(old, new)
+			e.ObjectNew = nil
+			Expect(pred.Update(e)).To(BeFalse())
+		})
+		By("the new metadata being nil", func() {
+			old, new := &appsv1.Deployment{}, &appsv1.Deployment{}
+			e = makeEventFor(old, new)
+			e.MetaNew = nil
+			Expect(pred.Update(e)).To(BeFalse())
+		})
+	})
+
+})
+
+func makeEventFor(old, new controllerutil.Object) (e event.UpdateEvent) {
+	e.ObjectOld, e.MetaOld = old, old
+	e.ObjectNew, e.MetaNew = new, new
+	return e
+}

--- a/predicate/predicate_suite_test.go
+++ b/predicate/predicate_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPredicate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Predicate Suite")
+}


### PR DESCRIPTION
This PR adds `NoGenerationPredicate`, moved from [operator-sdk's `GenerationChangedPredicate`](https://github.com/operator-framework/operator-sdk/blob/v0.19.0/pkg/predicate/predicate.go#L29), renamed, and updated to only allow objects that do not respect Generation to pass.

/cc @joelanford @jmrodri @hasbro17 