### PR TITLE
leader: check the node status for the leader-election (#24)

### DIFF
--- a/leader/leader.go
+++ b/leader/leader.go
@@ -167,7 +167,6 @@ func Become(ctx context.Context, lockName string, opts ...Option) error {
 				log.Info("Leader lock configmap owner reference must be a pod.", "OwnerReference", existingOwners[0])
 			default:
 				leaderPod := &corev1.Pod{}
-				// leaderNode := &corev1.Node{}
 				key = crclient.ObjectKey{Namespace: ns, Name: existingOwners[0].Name}
 				err = config.Client.Get(ctx, key, leaderPod)
 				switch {

--- a/leader/leader_test.go
+++ b/leader/leader_test.go
@@ -254,6 +254,12 @@ var _ = Describe("Leader election", func() {
 				},
 			}
 		})
+
+		It("should return false if node is invalid", func() {
+			client = fake.NewFakeClient()
+			ret := isNotReadyNode(context.TODO(), client, "")
+			Expect(ret).To(Equal(false))
+		})
 		It("should return false if no NodeCondition is found", func() {
 			client = fake.NewFakeClient(node)
 			ret := isNotReadyNode(context.TODO(), client, nodeName)


### PR DESCRIPTION
<!--

Welcome to the Operator Lib! Before contributing, make sure to:

- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
node-check for leader re-election #24 

**Motivation for the change:**
#24 
Check the condition of the node where the leader pod is running with [Node.Type == "NodeReady" && Node.Status != "ConditionTrue"] and when the node has been failed, delete the leaderPod (only mark the pod with 'terminating' because the node where the pod is running has been failed) and the configmap lock whose OwnerReference is leaderPod). 

This approach can bring more reliability 

