### PR TITLE
.github/workflows: remove make build task (already covered in prow test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,6 @@ jobs:
     - name: Get dependencies
       run: go mod download
 
-    - name: Build
-      run: make build
-
     - name: Test
       run: make test
 


### PR DESCRIPTION
<!--

Welcome to the Operator Lib! Before contributing, make sure to:

- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Remove `make build` from github actions CI workflow.

**Motivation for the change:**
All required tests in this repo are executed via prow.

The remaining GitHub actions are now optional checks that produce nice GH integrations with GolangCI lint and Coveralls. The `make build` step in the GH action is duplicative of a step in the prow tests and it doesn't produce any helpful integrations, so remove it to keep the GH workflow limited to the things that prow can't do.

