### PR TITLE
Bumping to Go 1.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ^1.15
       id: go
 
     - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/operator-lib
 
-go 1.13
+go 1.15
 
 require (
 	github.com/onsi/ginkgo v1.12.1


### PR DESCRIPTION
**Description of the change:**
Bumping go from 1.13 to 1.15 in `go.mod`.

**Motivation for the change:**
Moving to Go 1.15 like we did for operator-sdk: https://github.com/operator-framework/operator-sdk/blob/master/go.mod#L3

