### PR TITLE
predicate: Remove duplicate object validation

### DIFF
--- a/predicate/nogeneration.go
+++ b/predicate/nogeneration.go
@@ -60,19 +60,11 @@ type NoGenerationPredicate struct {
 // Update implements the default UpdateEvent filter for validating absence Generation.
 func (NoGenerationPredicate) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld == nil {
-		log.V(1).Info("Update event has no old metadata", "event", e)
-		return false
-	}
-	if e.ObjectOld == nil {
 		log.V(1).Info("Update event has no old runtime object to update", "event", e)
 		return false
 	}
 	if e.ObjectNew == nil {
 		log.V(1).Info("Update event has no new runtime object for update", "event", e)
-		return false
-	}
-	if e.ObjectNew == nil {
-		log.V(1).Info("Update event has no new metadata", "event", e)
 		return false
 	}
 	// Since generation is monotonically increasing, the new generation will always be greater than the old


### PR DESCRIPTION


<!--

Welcome to the Operator Lib! Before contributing, make sure to:

- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Remove duplicate object validation from NoGenerationPredicate.

Introduced while upgrading to controller-runtime v0.7.0 in #40 .
