### PR TITLE
Add option to read the operator namespace from an envirnment variable…

### DIFF
--- a/internal/utils/testfiles/namespace
+++ b/internal/utils/testfiles/namespace
@@ -1,0 +1,1 @@
+testnamespace

--- a/internal/utils/testfiles/namespaceWithSpaces
+++ b/internal/utils/testfiles/namespaceWithSpaces
@@ -1,0 +1,3 @@
+  testnamespace
+
+

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -23,6 +24,11 @@ import (
 
 var _ = Describe("Helpers test", func() {
 	Describe("GetOperatorNamespace", func() {
+		var origReadSAFile = readSAFile
+		AfterEach(func() {
+			readSAFile = origReadSAFile
+		})
+		const testNamespace = "testnamespace"
 		It("should return error when namespace not found", func() {
 			readSAFile = func() ([]byte, error) {
 				return nil, os.ErrNotExist
@@ -33,24 +39,129 @@ var _ = Describe("Helpers test", func() {
 		})
 		It("should return namespace", func() {
 			readSAFile = func() ([]byte, error) {
-				return []byte("testnamespace"), nil
+				return []byte(testNamespace), nil
 			}
 
 			// test
 			namespace, err := GetOperatorNamespace()
 			Expect(err).Should(BeNil())
-			Expect(namespace).To(Equal("testnamespace"))
+			Expect(namespace).To(Equal(testNamespace))
 		})
 		It("should trim whitespace from namespace", func() {
 			readSAFile = func() ([]byte, error) {
-				return []byte("   testnamespace    "), nil
+				return []byte("   " + testNamespace + "    "), nil
 			}
 
 			// test
 			namespace, err := GetOperatorNamespace()
-			Expect(err).Should(BeNil())
-			Expect(namespace).To(Equal("testnamespace"))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(namespace).To(Equal(testNamespace))
+		})
+		Context("read namespace from environment variable", func() {
+			var originalVal string
+			JustBeforeEach(func() {
+				originalVal = os.Getenv(OperatorNamespaceEnv)
+			})
+			JustAfterEach(func() {
+				err := os.Setenv(OperatorNamespaceEnv, originalVal)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+			It("should return the env var value, if set", func() {
+				err := os.Setenv(OperatorNamespaceEnv, testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				namespace, err := GetOperatorNamespace()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(namespace).To(Equal(testNamespace))
+			})
+			It("should trim spaces from the namespace", func() {
+				err := os.Setenv(OperatorNamespaceEnv, "   "+testNamespace+"   ")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				namespace, err := GetOperatorNamespace()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(namespace).To(Equal(testNamespace))
+			})
+			It("should return the namespace from a file if not the env var is not set", func() {
+				readSAFile = func() ([]byte, error) {
+					return []byte("namespace-from-file"), nil
+				}
+				err := os.Unsetenv(OperatorNamespaceEnv)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				namespace, err := GetOperatorNamespace()
+				Expect(err).Should(BeNil())
+				Expect(namespace).To(Equal("namespace-from-file"))
+
+			})
+			It("should return the namespace from a file if not the env var is only spaces", func() {
+				readSAFile = func() ([]byte, error) {
+					return []byte("namespace-from-file"), nil
+				}
+				err := os.Setenv(OperatorNamespaceEnv, "   ")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				namespace, err := GetOperatorNamespace()
+				Expect(err).Should(BeNil())
+				Expect(namespace).To(Equal("namespace-from-file"))
+			})
+		})
+		Context("read namespace from non standard location", func() {
+			var originalVal string
+			JustBeforeEach(func() {
+				originalVal = os.Getenv(SAFileLocationEnv)
+			})
+			JustAfterEach(func() {
+				err := os.Setenv(SAFileLocationEnv, originalVal)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+			It("should return the env var value, if set", func() {
+				err := os.Setenv(SAFileLocationEnv, getTestFilesDir()+"namespace")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				namespace, err := GetOperatorNamespace()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(namespace).To(Equal(testNamespace))
+			})
+			It("should trim spaces from the namespace", func() {
+				err := os.Setenv(SAFileLocationEnv, getTestFilesDir()+"namespaceWithSpaces")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				namespace, err := GetOperatorNamespace()
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(namespace).To(Equal(testNamespace))
+			})
+			It("should return error if the file is not exists", func() {
+				err := os.Setenv(SAFileLocationEnv, getTestFilesDir()+"notExists")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				namespace, err := GetOperatorNamespace()
+				Expect(err).Should(HaveOccurred())
+				Expect(err).Should(Equal(ErrNoNamespace))
+
+				Expect(namespace).Should(BeEmpty())
+			})
 		})
 	})
 
 })
+
+// return the path to the test files directory
+func getTestFilesDir() string {
+	const (
+		packageUnderTestPath = "internal/utils"
+		testFileDir          = "/testfiles/"
+	)
+
+	wd, err := os.Getwd()
+	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+
+	// if running form internal/utils/
+	if strings.HasSuffix(wd, packageUnderTestPath) {
+		return wd + testFileDir
+	}
+
+	// if running from repository root
+	return packageUnderTestPath + testFileDir
+}


### PR DESCRIPTION
…, or from a non-standard SA file.

While developing an operator, it is impossible to run from a local environment variable if the code
is trying to access the namespace file. For example, calling the `conditions.NewCondition` function
will return an error when the operator is running in a development environment.

This PR add to options to override the hard-coded path to the namespace file with another location:
1. by setting the new `OPERATOR_NAMESPACE` environment variable to the required namespace.
2. by setting the new `SA_FILE_PATH` environment variable to the local path of the namespace file.

If both new environment variables are set, the namespace will be taken from the `OPERATOR_NAMESPACE`
environment variable.

Fixes #50

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>