### PR TITLE
Add optional go-apidiff test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,22 @@ jobs:
       with:
         version: v1.29
         args: --timeout 5m
+
+  go-apidiff:
+    name: go-apidiff
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.15
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Run go-apidiff
+      uses: joelanford/go-apidiff@master


### PR DESCRIPTION
**Description of the change:**
Adds `joelanford/go-apidiff` to CI to detect breaking changes in PRs.

This project is currently being used in popular repositories already (e.g. kubernetes-sigs/controller-runtime and kubernetes-sigs/cluster-api)


**Motivation for the change:**
Make it easier for maintainers to detect breaking changes.


