### PR TITLE
Only run go-apidiff for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
 
   go-apidiff:
     name: go-apidiff
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
It doesn't really make sense to run it against other branches in this repo since there isn't anything to compare to.


