### PR TITLE
Depreciate ErrNoOperatorCondition

### DIFF
--- a/conditions/conditions.go
+++ b/conditions/conditions.go
@@ -29,6 +29,7 @@ import (
 
 var (
 	// ErrNoOperatorCondition indicates that the operator condition CRD is nil
+	// Depreciated
 	ErrNoOperatorCondition = fmt.Errorf("operator Condition CRD is nil")
 
 	// readNamespace gets the namespacedName of the operator.
@@ -72,7 +73,7 @@ func (c *condition) Get(ctx context.Context) (*metav1.Condition, error) {
 	operatorCond := &apiv2.OperatorCondition{}
 	err := c.client.Get(ctx, c.namespacedName, operatorCond)
 	if err != nil {
-		return nil, ErrNoOperatorCondition
+		return nil, err
 	}
 	con := meta.FindStatusCondition(operatorCond.Spec.Conditions, string(c.condType))
 
@@ -87,7 +88,7 @@ func (c *condition) Set(ctx context.Context, status metav1.ConditionStatus, opti
 	operatorCond := &apiv2.OperatorCondition{}
 	err := c.client.Get(ctx, c.namespacedName, operatorCond)
 	if err != nil {
-		return ErrNoOperatorCondition
+		return err
 	}
 
 	newCond := &metav1.Condition{

--- a/conditions/conditions_test.go
+++ b/conditions/conditions_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	apiv2 "github.com/operator-framework/api/pkg/operators/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -156,7 +157,7 @@ var _ = Describe("Condition", func() {
 				Expect(err).NotTo(HaveOccurred())
 				con, err := c.Get(ctx)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(ErrNoOperatorCondition))
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 				Expect(con).To(BeNil())
 			})
 
@@ -208,7 +209,7 @@ var _ = Describe("Condition", func() {
 				Expect(err).NotTo(HaveOccurred())
 				err = c.Set(ctx, metav1.ConditionTrue, WithReason("in_bar_state"), WithMessage("test"))
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(ErrNoOperatorCondition))
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			})
 
 		})


### PR DESCRIPTION
Problem: The ErrNoOperatorCondition does not surface any errors
encountered when retrieving OperatorConditions from the cluster.
It is not possible to know if there is an RBAC issue, if the
resource does not exist, or some other error.

Solution: Surface the error retrieving the OperatorCondition
