### PR TITLE
[WIP] feat(pattern): add job harvester pattern

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/operator-framework/api v0.10.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
+	go.uber.org/zap v1.17.0
 	k8s.io/api v0.21.1
 	k8s.io/apimachinery v0.21.1
 	k8s.io/client-go v0.21.1

--- a/pattern/jobharvest/clientgo.go
+++ b/pattern/jobharvest/clientgo.go
@@ -1,0 +1,21 @@
+package jobharvest
+
+import (
+	"k8s.io/client-go/kubernetes"
+)
+
+// NewControllerClientGo returns a controller with a Harvester registered for each opt in opts.
+func NewControllerClientGo(k8sClient kubernetes.Interface, opts ...*HarvesterOptions) (HarvestController, error) {
+	hc := &harvestController{
+		k8sClient: k8sClient,
+		hrvs:      make(harvesters),
+	}
+
+	for _, opt := range opts {
+		if _, err := hc.Create(opt); err != nil {
+			return nil, err
+		}
+	}
+
+	return hc, nil
+}

--- a/pattern/jobharvest/controller.go
+++ b/pattern/jobharvest/controller.go
@@ -1,0 +1,154 @@
+package jobharvest
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// HarvesterRegistrationKey is an annotation that should be set on a job if that
+	// job's name may be random.
+	HarvesterRegistrationKey = "job-harvester.operatorframework.io/registration-key"
+
+	controllerName = "job-harvester"
+)
+
+// HarvesterOptions configures a new Harvester.
+type HarvesterOptions struct {
+	Name      string
+	LogWriter LogWriter
+	RunOnce   bool
+	Cleanups  []func() error
+}
+
+// LogWriter writes logs from input stream io.Reader.
+type LogWriter interface {
+	WriteLogs(context.Context, io.Reader, corev1.Pod, string) error
+}
+
+// WriteLogsFunc implements LogWriter for functions.
+type WriteLogsFunc func(context.Context, io.Reader, corev1.Pod, string) error
+
+// WriteLogs calls f(args).
+func (f WriteLogsFunc) WriteLogs(ctx context.Context, stream io.Reader, pod corev1.Pod, ctrName string) error {
+	return f(ctx, stream, pod, ctrName)
+}
+
+// WriteLogsTo writes logs to w.
+func WriteLogsTo(w io.Writer) LogWriter {
+	return WriteLogsFunc(func(_ context.Context, stream io.Reader, _ corev1.Pod, _ string) error {
+		_, err := io.Copy(w, stream)
+		return err
+	})
+}
+
+// HarvestController is a controller for harvesters.
+type HarvestController interface {
+	Create(*HarvesterOptions) (Harvester, error)
+	Remove(*batchv1.Job) error
+	RemoveNamed(string) error
+}
+
+// harvestController reconciles all harvesters.
+type harvestController struct {
+	k8sClient  kubernetes.Interface
+	ctrlClient client.Client
+	hrvs       harvesters
+}
+
+// Create creates a new Harvester under name. Name must either be the exact
+// Job name or the string value for the HarvesterRegistrationKey annotation.
+func (hc *harvestController) Create(opts *HarvesterOptions) (Harvester, error) {
+	if hc.k8sClient == nil {
+		return nil, fmt.Errorf("k8sClient must be set")
+	}
+	// if hc.ctrlClient == nil {
+	// 	return nil, fmt.Errorf("ctrlClient must be set")
+	// }
+
+	h := &harvester{
+		name:       opts.Name,
+		k8sClient:  hc.k8sClient,
+		ctrlClient: hc.ctrlClient,
+	}
+
+	if h.name = opts.Name; h.name == "" {
+		return nil, fmt.Errorf("name must be set")
+	}
+	if h.lw = opts.LogWriter; h.lw == nil {
+		return nil, fmt.Errorf("log reader must be configured")
+	}
+
+	if err := hc.hrvs.register(opts.Name, &controlledHarvester{
+		harvester:  h,
+		runOnce:    opts.RunOnce,
+		cleanupFns: opts.Cleanups,
+	}); err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+// Remove removes job from the HarvesterController.
+func (hc *harvestController) Remove(job *batchv1.Job) error {
+	h, has := hc.hrvs.get(job)
+	if !has {
+		return nil
+	}
+
+	cleanupErrs := []error{}
+	for _, cleanup := range h.cleanupFns {
+		if err := cleanup(); err != nil {
+			cleanupErrs = append(cleanupErrs, err)
+		}
+	}
+	if len(cleanupErrs) != 0 {
+		return errors.NewAggregate(cleanupErrs)
+	}
+
+	delete(hc.hrvs, h.name)
+	return nil
+}
+
+// RemoveNamed removes harvester keyed with name from the HarvesterController.
+func (hc *harvestController) RemoveNamed(name string) error {
+	job := batchv1.Job{}
+	job.Name = name
+	return hc.Remove(&job)
+}
+
+type controlledHarvester struct {
+	*harvester
+	runOnce    bool
+	cleanupFns []func() error
+}
+
+type harvesters map[string]*controlledHarvester
+
+func (hs harvesters) register(name string, h *controlledHarvester) error {
+	if name == "" {
+		return fmt.Errorf("name cannot be empty")
+	}
+	if _, registered := hs[name]; registered {
+		return fmt.Errorf("harvester %q already registered", name)
+	}
+	hs[name] = h
+	return nil
+}
+
+func (hs harvesters) get(job *batchv1.Job) (h *controlledHarvester, registered bool) {
+	if h, registered = hs[job.Name]; !registered && job.Annotations != nil {
+		if regValue := job.Annotations[HarvesterRegistrationKey]; regValue != "" {
+			h, registered = hs[regValue]
+		}
+	}
+	return
+}

--- a/pattern/jobharvest/controller.go
+++ b/pattern/jobharvest/controller.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package jobharvest
 
 import (

--- a/pattern/jobharvest/ctrl.go
+++ b/pattern/jobharvest/ctrl.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package jobharvest
 
 import (

--- a/pattern/jobharvest/ctrl.go
+++ b/pattern/jobharvest/ctrl.go
@@ -1,0 +1,128 @@
+package jobharvest
+
+import (
+	"context"
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var (
+	logger = ctrllog.Log.WithName(controllerName)
+
+	// harvestController implements Reconcile.
+	_ reconcile.Reconciler = &harvestController{}
+)
+
+// NewControllerCtrl returns a controller with a Harvester registered for each opt in opts.
+//
+// **VERY IMPORTANT** - Many, many controllers use Jobs for various tasks, so there will likely
+// be many in some state at a given time. This means your cache will hydrate with each Job
+// in the set of watched namespaces, burdening your node unnecessarily.
+// Make sure your cache is set to only watch Jobs with the harvester's label applied,
+// and that these labels unique to your operator by using the operator's package name:
+//
+//  myJobLabels := labels.Set{"job-harvester": "foo-operator"}
+//  opts := manager.Options{
+//    NewCache: cache.BuilderWithOptions(cache.Options{
+//      SelectorsByObject: cache.SelectorsByObject{
+//        &batchv1.Job{}: {Label: myJobLabels.AsSelector()},
+//      },
+//    }),
+//  }
+//
+func NewControllerCtrl(k8sClient kubernetes.Interface, mgr manager.Manager, opts ...*HarvesterOptions) (HarvestController, error) {
+	hc := &harvestController{
+		k8sClient:  k8sClient,
+		ctrlClient: mgr.GetClient(),
+		hrvs:       make(harvesters),
+	}
+
+	for _, opt := range opts {
+		if _, err := hc.Create(opt); err != nil {
+			return nil, err
+		}
+	}
+
+	ctrlOpts := controller.Options{
+		Reconciler: hc,
+		Log:        logger,
+	}
+	c, err := controller.New(controllerName, mgr, ctrlOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &batchv1.Job{}},
+		&handler.EnqueueRequestForObject{},
+		predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				job, newIsJob := e.ObjectNew.(*batchv1.Job)
+				if newIsJob {
+					if job.Spec.Suspend != nil && *job.Spec.Suspend {
+						logger.V(1).Info("job suspended", "jobName", job.Name, "jobNamespace", job.Namespace)
+						return false
+					}
+					if job.Status.CompletionTime == nil {
+						logger.V(1).Info("job not completed", "jobName", job.Name, "jobNamespace", job.Namespace)
+						return false
+					}
+				}
+				return newIsJob
+			},
+			CreateFunc:  func(event.CreateEvent) bool { return false },
+			DeleteFunc:  func(event.DeleteEvent) bool { return false },
+			GenericFunc: func(event.GenericEvent) bool { return false },
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	return hc, nil
+}
+
+// Reconcile implements reconcile.Reconciler on harvestController.
+func (hc *harvestController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	jobLog := ctrllog.FromContext(ctx).WithValues("jobName", req.Name, "jobNamespace", req.Namespace)
+
+	job := &batchv1.Job{}
+	if err := hc.ctrlClient.Get(ctx, req.NamespacedName, job); err != nil {
+		if errors.IsNotFound(err) {
+			jobLog.V(1).Info("harvester not found; are you sure your controller is constrained to watching only labeled Jobs?")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+	h, has := hc.hrvs.get(job)
+	if !has {
+		jobLog.Error(fmt.Errorf("harvester not registered"), "")
+		return reconcile.Result{}, nil
+	}
+
+	h.logger = jobLog
+	if err := h.runCtrl(ctx, job); err != nil {
+		jobLog.Error(err, "harvester run failed")
+		// QUESTION(estroz): requeue and risk duplicating log read (usually log engines will deduplicate)
+		// or just let the error slide? Probably requeue or somehow guarantee more Job deletion attempts.
+		return reconcile.Result{Requeue: true}, nil
+	}
+
+	if h.runOnce {
+		if err := hc.Remove(job); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pattern/jobharvest/example_test.go
+++ b/pattern/jobharvest/example_test.go
@@ -1,0 +1,204 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jobharvest_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/operator-framework/operator-lib/pattern/jobharvest"
+)
+
+// This example creates a HarvesterController controller with controller-runtime libraries
+// managed by a manager.Manager to extract Job logs in various situations.
+func ExampleNewControllerCtrl() {
+	checkErr := func(err error) {
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	cfg := config.GetConfigOrDie()
+
+	// Labels that, when applied to a Job, will trigger harvester reconciles
+	// on updates. Make these labels unique to your operator by using the
+	// operator's package name.
+	jobLabels := labels.Set{"job-harvester": "foo-operator"}
+
+	// **VERY IMPORTANT** - Many, many controllers use Jobs for various tasks,
+	// so there will likely be many in some state at a given time. This means
+	// your cache will hydrate with each Job in the set of watched namespaces,
+	// burdening your node unnecessarily. Make sure your cache is set to only
+	// watch Jobs with the harvester's label applied.
+	opts := manager.Options{
+		NewCache: cache.BuilderWithOptions(cache.Options{
+			SelectorsByObject: cache.SelectorsByObject{
+				&batchv1.Job{}: {Label: jobLabels.AsSelector()},
+			},
+		}),
+	}
+	mgr, err := manager.New(cfg, opts)
+	checkErr(err)
+
+	createLogFile := func(name string) (*os.File, error) {
+		return os.OpenFile("/var/log/"+name, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	}
+
+	// Jobs known beforehand.
+	fooJobFile, err := createLogFile("job-foo.log")
+	checkErr(err)
+	defer fooJobFile.Close()
+	harvesterOpts := []*jobharvest.HarvesterOptions{
+		{Name: "job-foo", LogWriter: jobharvest.WriteLogsTo(fooJobFile)},
+	}
+
+	// Create the Job harvester controller with one harvester per option
+	// and add it to the manager.
+	hf, err := jobharvest.NewControllerCtrl(kubernetes.NewForConfigOrDie(cfg), mgr, harvesterOpts...)
+	checkErr(err)
+
+	// Example reconciler function that uses the HarvesterFactory in several ways.
+	var r reconcile.Func = func(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+		// 1. Existing Job harvesting, in which a Job is created on each reconcile
+		// if one does not exist that has the same name every time.
+		// This Job is harvested by the "job-foo" harvester by direct name matching.
+		systemJob := newJob("job-foo", "operator-system")
+		for k, v := range jobLabels {
+			systemJob.Labels[k] = v
+		}
+		if err := mgr.GetClient().Create(ctx, systemJob); err != nil && !errors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+
+		pod := &v1.Pod{}
+		if err := mgr.GetClient().Get(ctx, req.NamespacedName, pod); err != nil {
+			return reconcile.Result{}, err
+		}
+		if needsJob(pod) {
+			// 2. Dynamic Job harvesting, where the Job's name might not be known beforehand
+			// but an existing harvester needs to be re-used.
+			job := newJobForPod(pod)
+			for k, v := range jobLabels {
+				job.Labels[k] = v
+			}
+			// Re-use the existing "job-foo" harvester to write logs to the same location
+			// by setting a registration annotation with the registered harvester's name.
+			job.Annotations[jobharvest.HarvesterRegistrationKey] = "job-foo"
+			if err := mgr.GetClient().Create(ctx, job); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+
+		// 3. Constructing harvesters on the fly, where a new harvester is
+		// needed when some condition is true. For example,
+		// this controller also owns some services that require inspection
+		// with a Job if have bad LB port configurations, and a new Job per
+		// service created is required, each with its own harvester so logs
+		// are written to unique destinations.
+		svcList := &v1.ServiceList{}
+		if err := mgr.GetClient().List(ctx, svcList, client.InNamespace(req.Namespace)); err != nil {
+			return reconcile.Result{}, err
+		}
+		lbIngressHasPortError := func(ingresses []v1.LoadBalancerIngress) bool {
+			for _, ingressStatus := range ingresses {
+				for _, portStatus := range ingressStatus.Ports {
+					if portStatus.Error != nil {
+						return true
+					}
+				}
+			}
+			return false
+		}
+		erroredSvcNames := []string{}
+		for _, svc := range svcList.Items {
+			if lbIngressHasPortError(svc.Status.LoadBalancer.Ingress) {
+				erroredSvcNames = append(erroredSvcNames, svc.Name)
+			}
+		}
+		// Create the harvester first so the job will definitely be cleaned up when done.
+		jobName := fmt.Sprintf("service-job-%d", time.Now().UnixNano())
+		jobFile, err := createLogFile(jobName + ".log")
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		hrvOpts := &jobharvest.HarvesterOptions{
+			Name:      jobName,
+			LogWriter: jobharvest.WriteLogsTo(jobFile),
+			// This job is a one-off, so delete the harvester and
+			// clean up the file when done.
+			RunOnce:  true,
+			Cleanups: []func() error{jobFile.Close},
+		}
+		if _, err := hf.Create(hrvOpts); err != nil {
+			log.FromContext(ctx).Error(err, "failed to create job harvester")
+			return reconcile.Result{}, nil
+		}
+		svcJob := newServicesJob(jobName, "operator-system", erroredSvcNames)
+		if err := mgr.GetClient().Create(ctx, svcJob); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, nil
+	}
+
+	checkErr(builder.ControllerManagedBy(mgr).For(&v1.Pod{}).Complete(r))
+
+	// **VERY IMPORTANT** - Register the job harvest webhook, which adds a finalizer
+	// to jobs in case spec.ttlSecondsAfterFinished is set. Setting this field is
+	// good practice since it results in that job being garbage collected after completion.
+	// Prior to that however, the job harvester needs to read each container's logs
+	// and so prevents their deletion with this finalizer. Add the following comment
+	// to your main.go or a controller Go file to generate a webhook config for your project:
+	//
+	// +kubebuilder:webhook:path=/job-harvester,mutating=true,failurePolicy=fail,groups="batch",resources=jobs,verbs=create;update,versions=v1,name=job-harvester.my.domain.io
+	//
+	mgr.GetWebhookServer().Register("/job-harvester", &webhook.Admission{Handler: &jobharvest.Webhook{}})
+
+	checkErr(mgr.Start(signals.SetupSignalHandler()))
+}
+
+func needsJob(pod *v1.Pod) bool { return true }
+func newJobForPod(pod *v1.Pod) *batchv1.Job {
+	return newJob("job-"+pod.Name, pod.Namespace)
+}
+func newServicesJob(name, namespace string, _ []string) *batchv1.Job {
+	return newJob(name, namespace)
+}
+func newJob(name, namespace string) *batchv1.Job {
+	job := &batchv1.Job{}
+	job.Name = name
+	job.Namespace = namespace
+	job.Labels = make(map[string]string)
+	job.Annotations = make(map[string]string)
+	return job
+}

--- a/pattern/jobharvest/harvester.go
+++ b/pattern/jobharvest/harvester.go
@@ -1,0 +1,230 @@
+package jobharvest
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// Harvester harvests a job when run.
+type Harvester interface {
+	Run(context.Context, *batchv1.Job) error
+}
+
+// harvester harvests jobs.
+type harvester struct {
+	name       string
+	logger     logr.Logger
+	k8sClient  kubernetes.Interface
+	ctrlClient client.Client
+	lw         LogWriter
+}
+
+// Run streams logs of all containers in job if job is complete.
+func (h *harvester) Run(ctx context.Context, job *batchv1.Job) error {
+
+	if shouldSkip(job) {
+		return nil
+	}
+
+	if h.ctrlClient != nil {
+		return h.runCtrl(ctx, job)
+	}
+	return h.runClientGo(ctx, job)
+}
+
+func shouldSkip(job *batchv1.Job) bool {
+	// Skip suspended jobs, since they will not spawn pods.
+	suspended := job.Spec.Suspend != nil && *job.Spec.Suspend
+	// To avoid duplicate streamed logs, skip jobs until they are complete
+	// and their containers finish running.
+	notComplete := job.Status.CompletionTime == nil
+
+	return suspended || notComplete
+}
+
+// runCtrl streams logs of all containers in job if job is complete
+// using a controller-runtime client.
+func (h *harvester) runCtrl(ctx context.Context, job *batchv1.Job) error {
+
+	// QUESTION(estroz): handle job.Spec.ManualSelector?
+	sel, err := metav1.LabelSelectorAsSelector(job.Spec.Selector)
+	if err != nil {
+		return err
+	}
+	podList := &corev1.PodList{}
+	podListOpts := []client.ListOption{
+		client.MatchingLabelsSelector{Selector: sel},
+		client.InNamespace(job.Namespace),
+	}
+	if err := h.ctrlClient.List(ctx, podList, podListOpts...); err != nil {
+		return err
+	}
+
+	if err := streamPodLogs(ctx, h.k8sClient, podList, h.lw, h.logger); err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, pod := range podList.Items {
+		podLog := h.logger.WithValues("jobName", job.Name, "podName", pod.Name, "podNamespace", pod.Namespace)
+
+		if controllerutil.ContainsFinalizer(&pod, jobFinalizer) {
+			podLog.V(1).Info("removing finalizer")
+
+			controllerutil.RemoveFinalizer(&pod, jobFinalizer)
+			if err := h.ctrlClient.Update(ctx, &pod); err != nil {
+				podLog.Error(err, "updating pod to remove finalizer")
+				errs = append(errs, err)
+				continue
+			}
+		}
+	}
+
+	if controllerutil.ContainsFinalizer(job, jobFinalizer) {
+		h.logger.V(1).Info("removing finalizer")
+
+		controllerutil.RemoveFinalizer(job, jobFinalizer)
+		if err := h.ctrlClient.Update(ctx, job); err != nil {
+			h.logger.Error(err, "updating job to remove finalizer")
+			return utilerrors.NewAggregate(append(errs, err))
+		}
+	}
+
+	if job.Spec.TTLSecondsAfterFinished == nil {
+		h.logger.V(1).Info("deleting job, ttlSecondsAfterFinished unset")
+
+		// Set TTL to 0 to have the TTL controller delete the Job and its Pods.
+		pt := types.StrategicMergePatchType
+		p := []byte(`{"spec":{"ttlSecondsAfterFinished":0}}`)
+		opts := []client.PatchOption{
+			client.FieldOwner(controllerName),
+		}
+		if err := h.ctrlClient.Patch(ctx, job, client.RawPatch(pt, p), opts...); err != nil {
+			h.logger.Error(err, "delete job")
+			return utilerrors.NewAggregate(append(errs, err))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+// runCtrl streams logs of all containers in job if job is complete
+// using a client-go client.
+func (h *harvester) runClientGo(ctx context.Context, job *batchv1.Job) error {
+
+	// QUESTION(estroz): handle job.Spec.ManualSelector?
+	sel, err := metav1.LabelSelectorAsSelector(job.Spec.Selector)
+	if err != nil {
+		return err
+	}
+	opts := metav1.ListOptions{
+		LabelSelector: sel.String(),
+	}
+	podList, err := h.k8sClient.CoreV1().Pods(job.Namespace).List(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	if err := streamPodLogs(ctx, h.k8sClient, podList, h.lw, h.logger); err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, pod := range podList.Items {
+		podLog := h.logger.WithValues("jobName", job.Name, "podName", pod.Name, "podNamespace", pod.Namespace)
+
+		if controllerutil.ContainsFinalizer(&pod, jobFinalizer) {
+			podLog.V(1).Info("removing finalizer")
+
+			controllerutil.RemoveFinalizer(&pod, jobFinalizer)
+			if _, err = h.k8sClient.CoreV1().Pods(pod.Namespace).Update(ctx, &pod, metav1.UpdateOptions{}); err != nil {
+				podLog.Error(err, "updating pod to remove finalizer")
+				errs = append(errs, err)
+				continue
+			}
+		}
+	}
+
+	if controllerutil.ContainsFinalizer(job, jobFinalizer) {
+		h.logger.V(1).Info("removing finalizer")
+
+		controllerutil.RemoveFinalizer(job, jobFinalizer)
+		if job, err = h.k8sClient.BatchV1().Jobs(job.Namespace).Update(ctx, job, metav1.UpdateOptions{}); err != nil {
+			h.logger.Error(err, "updating job to remove finalizer")
+			return utilerrors.NewAggregate(append(errs, err))
+		}
+	}
+
+	if job.Spec.TTLSecondsAfterFinished == nil {
+		h.logger.V(1).Info("deleting job, ttlSecondsAfterFinished unset")
+
+		// Set TTL to 0 to have the TTL controller delete the Job and its Pods.
+		pt := types.MergePatchType
+		p := []byte(`{"spec":{"ttlSecondsAfterFinished":0}}`)
+		opts := metav1.PatchOptions{
+			FieldManager: controllerName,
+		}
+		if _, err = h.k8sClient.BatchV1().Jobs(job.Namespace).Patch(ctx, job.Name, pt, p, opts); err != nil {
+			h.logger.Error(err, "delete job")
+			return utilerrors.NewAggregate(append(errs, err))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+func streamPodLogs(ctx context.Context, k8sClient kubernetes.Interface, podList *corev1.PodList, lw LogWriter, l logr.Logger) error {
+
+	var errs []error
+	for _, pod := range podList.Items {
+		podLog := l.WithValues("podName", pod.Name, "podNamespace", pod.Namespace)
+		podLog.V(1).Info("found pod")
+
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+
+			err := func() error {
+
+				ctrLog := podLog.WithValues("container", containerStatus.Name)
+				ctrLog.V(1).Info("streaming logs")
+
+				logOpts := corev1.PodLogOptions{
+					Container:  containerStatus.Name,
+					Follow:     true,
+					Timestamps: true,
+				}
+				rc, err := k8sClient.CoreV1().Pods(pod.GetNamespace()).GetLogs(pod.GetName(), &logOpts).Stream(ctx)
+				if err != nil {
+					ctrLog.Error(err, "stream logs")
+					return err
+				}
+				defer func() {
+					if err := rc.Close(); err != nil {
+						ctrLog.Error(err, "close stream")
+					}
+				}()
+
+				if err := lw.WriteLogs(ctx, rc, pod, containerStatus.Name); err != nil {
+					ctrLog.Error(err, "read logs")
+					return err
+				}
+
+				return nil
+			}()
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}

--- a/pattern/jobharvest/harvester.go
+++ b/pattern/jobharvest/harvester.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package jobharvest
 
 import (
@@ -75,7 +89,7 @@ func (h *harvester) runCtrl(ctx context.Context, job *batchv1.Job) error {
 
 	var errs []error
 	for _, pod := range podList.Items {
-		podLog := h.logger.WithValues("jobName", job.Name, "podName", pod.Name, "podNamespace", pod.Namespace)
+		podLog := h.logger.WithValues("podName", pod.Name, "podNamespace", pod.Namespace)
 
 		if controllerutil.ContainsFinalizer(&pod, jobFinalizer) {
 			podLog.V(1).Info("removing finalizer")
@@ -140,7 +154,7 @@ func (h *harvester) runClientGo(ctx context.Context, job *batchv1.Job) error {
 
 	var errs []error
 	for _, pod := range podList.Items {
-		podLog := h.logger.WithValues("jobName", job.Name, "podName", pod.Name, "podNamespace", pod.Namespace)
+		podLog := h.logger.WithValues("podName", pod.Name, "podNamespace", pod.Namespace)
 
 		if controllerutil.ContainsFinalizer(&pod, jobFinalizer) {
 			podLog.V(1).Info("removing finalizer")

--- a/pattern/jobharvest/harvester_test.go
+++ b/pattern/jobharvest/harvester_test.go
@@ -1,0 +1,243 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jobharvest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var _ = Describe("Harvester", func() {
+	Context("controller-runtime", func() {
+		const (
+			podName1 = "foo-1234"
+			ns       = "default"
+		)
+
+		var (
+			ctx       context.Context
+			logStderr *bytes.Buffer
+			podLogBuf *bytes.Buffer
+			lw        LogWriter
+
+			trueP = new(bool)
+		)
+
+		BeforeEach(func() {
+			*trueP = true
+			ctx = context.TODO()
+			logStderr = &bytes.Buffer{}
+			podLogBuf = &bytes.Buffer{}
+			lw = WriteLogsTo(podLogBuf)
+		})
+
+		It("skips a suspended job", func() {
+			job := newJob("foo", ns)
+			job.Spec.Suspend = trueP
+			h := newFakeHarvesterCtrl("foo", lw, logStderr, job)
+
+			By("running the harvester")
+			Expect(h.Run(ctx, job)).To(Succeed())
+		})
+
+		It("skips an incomplete job", func() {
+			job := newJob("foo", ns)
+			job.Status.CompletionTime = nil
+			h := newFakeHarvesterCtrl("foo", lw, logStderr, job)
+
+			By("running the harvester")
+			Expect(h.Run(ctx, job)).To(Succeed())
+		})
+
+		It("harvests a job's single pod", func() {
+			job := newJob("foo", ns)
+			parentLabels := labels.Set{"id": "1234-5678-9123"}
+			// This is usually set by the Job controller.
+			job.Spec.Selector = v1.SetAsLabelSelector(parentLabels)
+			pod := newPod(podName1, ns, parentLabels, corev1.ContainerStatus{Name: "runner"})
+			h := newFakeHarvesterCtrl("foo", lw, logStderr, job, pod)
+
+			By("verifying ttlSecondsAfterFinished is unset")
+			Expect(job.Spec.TTLSecondsAfterFinished).To(BeNil())
+
+			By("running the harvester")
+			Expect(h.Run(ctx, job)).To(Succeed())
+
+			By("checking pod logs")
+			Expect(podLogBuf.String()).To(Equal("fake logs"))
+
+			By("setting ttlSecondsAfterFinished to 0")
+			updatedJob := &batchv1.Job{}
+			Expect(h.ctrlClient.Get(ctx, client.ObjectKeyFromObject(job), updatedJob)).To(Succeed())
+			zero := new(int32)
+			Expect(updatedJob.Spec.TTLSecondsAfterFinished).To(Equal(zero))
+		})
+
+		It("removing all finalizers", func() {
+			job := newJob("foo", ns)
+			WithFinalizers(job)
+			// Set some other finalizer so we know the harvester isn't removing them all.
+			const otherFinalizer = "other/finalizer"
+			job.Finalizers = append(job.Finalizers, otherFinalizer)
+			parentLabels := labels.Set{"id": "1234-5678-9123"}
+			// This is usually set by the Job controller.
+			job.Spec.Selector = v1.SetAsLabelSelector(parentLabels)
+			pod := newPod(podName1, ns, parentLabels, corev1.ContainerStatus{Name: "runner"})
+			pod.Finalizers = append(pod.Finalizers, jobFinalizer)
+			h := newFakeHarvesterCtrl("foo", lw, logStderr, job, pod)
+			// Simulate controller caller log setup.
+			h.logger = h.logger.WithValues("jobName", job.Name, "jobNamespace", job.Namespace)
+
+			By("verifying ttlSecondsAfterFinished is unset")
+			Expect(job.Spec.TTLSecondsAfterFinished).To(BeNil())
+
+			By("running the harvester")
+			Expect(h.Run(ctx, job)).To(Succeed())
+
+			By("checking for pod finalizer removal")
+			updatedPod := &corev1.Pod{}
+			Expect(h.ctrlClient.Get(ctx, client.ObjectKeyFromObject(pod), updatedPod)).To(Succeed())
+			Expect(updatedPod.Finalizers).To(HaveLen(0))
+
+			By("checking for job finalizer removal")
+			updatedJob := &batchv1.Job{}
+			Expect(h.ctrlClient.Get(ctx, client.ObjectKeyFromObject(job), updatedJob)).To(Succeed())
+			Expect(updatedJob.Finalizers).To(Equal([]string{otherFinalizer}))
+
+			By("checking pod logs")
+			Expect(podLogBuf.String()).To(Equal("fake logs"))
+
+			By("setting ttlSecondsAfterFinished to 0")
+			zero := new(int32)
+			Expect(job.Spec.TTLSecondsAfterFinished).To(Equal(zero))
+		})
+
+		It("stream two pod's logs", func() {
+			job := newJob("foo", ns)
+			parentLabels := labels.Set{"id": "1234-5678-9123"}
+			// This is usually set by the Job controller.
+			job.Spec.Selector = v1.SetAsLabelSelector(parentLabels)
+			pod1 := newPod(podName1, ns, parentLabels, corev1.ContainerStatus{Name: "runner"}, corev1.ContainerStatus{Name: "do-er"})
+			pod2 := newPod("foo-4567", ns, parentLabels, corev1.ContainerStatus{Name: "runner"}, corev1.ContainerStatus{Name: "do-er"})
+			h := newFakeHarvesterCtrl("foo", lw, logStderr, job, pod1, pod2)
+
+			By("running the harvester")
+			Expect(h.Run(ctx, job)).To(Succeed())
+
+			By("decoding Run logs")
+			logs := decodeLogs(logStderr)
+
+			By("checking pod iterator logs")
+			lls := []logLine{
+				{PodName: podName1, PodNamespace: ns, Container: "runner", Msg: "streaming logs"},
+				{PodName: podName1, PodNamespace: ns, Container: "do-er", Msg: "streaming logs"},
+				{PodName: "foo-4567", PodNamespace: ns, Container: "runner", Msg: "streaming logs"},
+				{PodName: "foo-4567", PodNamespace: ns, Container: "do-er", Msg: "streaming logs"},
+			}
+			Expect(logs).To(ContainElements(lls))
+
+			By("checking pod logs")
+			Expect(podLogBuf.String()).To(Equal("fake logsfake logsfake logsfake logs"))
+		})
+
+		It("fails to find job in the same namespace different name", func() {
+			otherJob := newJob("foo", ns)
+			h := newFakeHarvesterCtrl("bar", lw, logStderr, otherJob)
+
+			By("running the harvester")
+			Expect(h.Run(ctx, otherJob)).To(Succeed())
+
+			By("checking pod logs")
+			Expect(podLogBuf.Len()).To(Equal(0))
+		})
+
+		It("fails to find job in a different namespace same name", func() {
+			otherJob := newJob("foo", "other")
+			h := newFakeHarvesterCtrl("foo", lw, logStderr, otherJob)
+
+			By("running the harvester")
+			Expect(h.Run(ctx, otherJob)).To(Succeed())
+
+			By("checking pod logs")
+			Expect(podLogBuf.Len()).To(Equal(0))
+		})
+	})
+})
+
+func newJob(name, namespace string) *batchv1.Job { //nolint:unparam
+	job := &batchv1.Job{}
+	job.Name = name
+	job.Namespace = namespace
+	now := v1.Now()
+	job.Status.CompletionTime = &now
+	return job
+}
+
+func newPod(name, namespace string, lbls labels.Set, ctrStatuses ...corev1.ContainerStatus) *corev1.Pod { //nolint:unparam
+	pod := &corev1.Pod{}
+	pod.Name = name
+	pod.Namespace = namespace
+	pod.Labels = lbls
+	pod.Status.ContainerStatuses = ctrStatuses
+	return pod
+}
+
+func newFakeHarvesterCtrl(name string, lw LogWriter, logStderr io.Writer, objs ...client.Object) *harvester {
+	h := &harvester{name: name}
+	h.logger = zap.New(zap.WriteTo(logStderr), zap.Level(zapcore.DebugLevel))
+	h.lw = lw
+	runtimeObjs := make([]runtime.Object, len(objs))
+	for i := range objs {
+		runtimeObjs[i] = objs[i]
+	}
+	h.k8sClient = k8sfake.NewSimpleClientset(runtimeObjs...)
+	h.ctrlClient = ctrlfake.NewClientBuilder().WithObjects(objs...).Build()
+	return h
+}
+
+type logLine struct {
+	JobName      string
+	JobNamespace string
+	PodName      string
+	PodNamespace string
+	Container    string
+	Msg          string
+	Error        string
+}
+
+func decodeLogs(r io.Reader) (logs []logLine) {
+	dec := json.NewDecoder(r)
+	for dec.More() {
+		var ll logLine
+		ExpectWithOffset(1, dec.Decode(&ll)).To(Succeed())
+		logs = append(logs, ll)
+	}
+	return logs
+}

--- a/pattern/jobharvest/suite_test.go
+++ b/pattern/jobharvest/suite_test.go
@@ -15,22 +15,13 @@
 package jobharvest
 
 import (
-	"k8s.io/client-go/kubernetes"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-// NewControllerClientGo returns a controller with a Harvester registered for each opt in opts.
-// TODO(estroz): flesh this out.
-func NewControllerClientGo(k8sClient kubernetes.Interface, opts ...*HarvesterOptions) (HarvestController, error) {
-	hc := &harvestController{
-		k8sClient: k8sClient,
-		hrvs:      make(harvesters),
-	}
-
-	for _, opt := range opts {
-		if _, err := hc.Create(opt); err != nil {
-			return nil, err
-		}
-	}
-
-	return hc, nil
+func TestJobHarvest(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "JobHarvest Suite")
 }

--- a/pattern/jobharvest/webhook.go
+++ b/pattern/jobharvest/webhook.go
@@ -1,0 +1,67 @@
+package jobharvest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	batchv1 "k8s.io/api/batch/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const jobFinalizer = "job-harvester.operatorframework.io/finalizer"
+
+// WithFinalizers sets finalizer on job and its pod template.
+func WithFinalizers(job *batchv1.Job) {
+	controllerutil.AddFinalizer(job, jobFinalizer)
+	for _, f := range job.Spec.Template.Finalizers {
+		if f == jobFinalizer {
+			return
+		}
+	}
+	job.Spec.Template.Finalizers = append(job.Spec.Template.Finalizers, jobFinalizer)
+}
+
+var (
+	_ admission.DecoderInjector = &Webhook{}
+	_ admission.Handler         = &Webhook{}
+)
+
+// Webhook adds jobFinalizer to Jobs and their Pod template.
+type Webhook struct {
+	// SetTTL controls if the webhook sets Job.Spec.TTLSecondsAfterFinished = 0
+	// on the Job so it is automatically garbage collected once finished.
+	// Defaults to true.
+	SetTTL *bool
+
+	decoder *admission.Decoder
+}
+
+// Handle adds jobFinalizer to every incoming Job.
+func (w *Webhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+
+	job := &batchv1.Job{}
+	if err := w.decoder.Decode(req, job); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	WithFinalizers(job)
+	// Set TTLSecondsAfterFinished by default or if explicitly specified.
+	if w.SetTTL == nil || *w.SetTTL {
+		job.Spec.TTLSecondsAfterFinished = new(int32)
+	}
+
+	b, err := json.Marshal(job)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, b)
+}
+
+// InjectDecoder injects the decoder.
+func (w *Webhook) InjectDecoder(d *admission.Decoder) error {
+	w.decoder = d
+	return nil
+}

--- a/pattern/jobharvest/webhook.go
+++ b/pattern/jobharvest/webhook.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package jobharvest
 
 import (


### PR DESCRIPTION
**Description of the change:** added the `pattern/jobharvester` package with Job log forwarding and garbage collection functionality.

**Motivation for the change:** lots of operators spawn jobs for various tasks. This simple controller exposes both the primitive `Harvester` type to get a Job's Pod logs then delete the Pod, or a higher level controller implementation for low-LOC, background Job harvesting.

/kind feature

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

