### PR TITLE
Fix permission issue when settin the operator-condition

### DIFF
--- a/conditions/conditions.go
+++ b/conditions/conditions.go
@@ -98,7 +98,7 @@ func (c *condition) Set(ctx context.Context, status metav1.ConditionStatus, opti
 		}
 	}
 	meta.SetStatusCondition(&operatorCond.Spec.Conditions, *newCond)
-	err = c.client.Status().Update(ctx, operatorCond)
+	err = c.client.Update(ctx, operatorCond)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The conditions moved from the `Status` field to the `Spec`, but when setting the condition, the code still uses `client.Status().Update()` to set the condition, instead of just `client.Update()`. This is wrong in two ways: first, the code is trying to update the spec, so it will fail, and also, the operator does not have permissions to update the status. As result, the `Set` function always returns error.

This PR fixes #69.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!--

Welcome to the Operator Lib! Before contributing, make sure to:

- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
This PR changes the client call to use the regular client instead of the status client.


**Motivation for the change:**
Can't use the current version of the library to set an operator condition. This PR will allow using the lib.

