### PR TITLE
Add function to facilitate proxy-aware operators

### DIFF
--- a/proxy/doc.go
+++ b/proxy/doc.go
@@ -1,0 +1,34 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package proxy implements helper functions to facilitate making operators proxy-aware.
+
+This package assumes that proxy environment variables `HTTPS_PROXY`,
+`HTTP_PROXY`, and/or `NO_PROXY` are set in the Operator environment, typically
+via the Operator deployment.
+
+Proxy-aware operators can use the ReadProxyVarsFromEnv to retrieve these values
+as a slice of corev1 EnvVars. Each of the proxy variables are duplicated in
+upper and lower case to support applications that use either. In their
+reconcile functions, Operator authors are then responsible for setting these
+variables in the Container Envs that must use the proxy, For example:
+
+	// Pods with Kubernetes < 1.22
+	for _, cSpec := range (myPod.Spec.Containers) {
+		cSpec.Env = append(defaultEnv(), ReadProxyVarsFromEnv())
+	}
+*/
+
+package proxy

--- a/proxy/doc.go
+++ b/proxy/doc.go
@@ -30,5 +30,4 @@ variables in the Container Envs that must use the proxy, For example:
 		cSpec.Env = append(defaultEnv(), ReadProxyVarsFromEnv())
 	}
 */
-
 package proxy

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -24,7 +24,7 @@ import (
 // ProxyEnvNames are standard environment variables for proxies
 var ProxyEnvNames = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
 
-// ReadProxyVarssFromEnv retrieves the standard proxy-related environment
+// ReadProxyVarsFromEnv retrieves the standard proxy-related environment
 // variables from the running environment and returns a slice of corev1 EnvVar
 // containing upper and lower case versions of those variables.
 func ReadProxyVarsFromEnv() []corev1.EnvVar {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -30,16 +30,18 @@ var ProxyEnvNames = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
 func ReadProxyVarsFromEnv() []corev1.EnvVar {
 	envVars := []corev1.EnvVar{}
 	for _, s := range ProxyEnvNames {
-		value := os.Getenv(s)
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  s,
-			Value: value,
-		})
-		// Duplicate values for upper and lower case
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  strings.ToLower(s),
-			Value: value,
-		})
+		value, isSet := os.LookupEnv(s)
+		if isSet {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  s,
+				Value: value,
+			})
+			// Duplicate values for upper and lower case
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  strings.ToLower(s),
+				Value: value,
+			})
+		}
 	}
 	return envVars
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,0 +1,41 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var ProxyEnvNames = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+
+func ReadProxyVarsFromEnv() []corev1.EnvVar {
+	envVars := []corev1.EnvVar{}
+	for _, s := range ProxyEnvNames {
+		value := os.Getenv(s)
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  s,
+			Value: value,
+		})
+		// Duplicate values for upper and lower case
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  strings.ToLower(s),
+			Value: value,
+		})
+	}
+	return envVars
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -21,8 +21,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// ProxyEnvNames are standard environment variables for proxies
 var ProxyEnvNames = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
 
+// ReadProxyVarssFromEnv retrieves the standard proxy-related environment
+// variables from the running environment and returns a slice of corev1 EnvVar
+// containing upper and lower case versions of those variables.
 func ReadProxyVarsFromEnv() []corev1.EnvVar {
 	envVars := []corev1.EnvVar{}
 	for _, s := range ProxyEnvNames {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -35,9 +35,7 @@ func ReadProxyVarsFromEnv() []corev1.EnvVar {
 			envVars = append(envVars, corev1.EnvVar{
 				Name:  s,
 				Value: value,
-			})
-			// Duplicate values for upper and lower case
-			envVars = append(envVars, corev1.EnvVar{
+			}, corev1.EnvVar{
 				Name:  strings.ToLower(s),
 				Value: value,
 			})

--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -1,0 +1,13 @@
+package proxy_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestProxy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Proxy Suite")
+}

--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package proxy_test
 
 import (

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -36,23 +36,24 @@ func checkValueFromEnvObj(name string, envVars []corev1.EnvVar) (string, error) 
 
 var _ = Describe("Retrieving", func() {
 	Describe("proxy environment variables", func() {
-		// TODO(asmacdo) seems like a bad idea to mess with the env
-		BeforeEach(func() {
+		It("returns a slice of environment variables that were set", func() {
 			os.Setenv("HTTPS_PROXY", "https_proxy_test")
-			// 	os.Setenv("HTTP_PROXY", "http_proxy_test")
-			// 	os.Setenv("NO_PROXY", "no_proxy_test")
-		})
-		It("returns a slice of environment variables", func() {
+			os.Setenv("HTTP_PROXY", "http_proxy_test")
+			os.Setenv("NO_PROXY", "no_proxy_test")
 			envVars := ReadProxyVarsFromEnv()
 			Expect(len(envVars)).To(Equal(6))
 		})
-		It("creates upper and lower case environment variables with the same value", func() {
+		It("does not return unset variables", func() {
 			envVars := ReadProxyVarsFromEnv()
-			// dumb, err := checkValueFromEnvObj("HTTPS_PROXY", envVars)
-			// Expect(err).To(BeNil())
-			// Expect(dumb).To(Equal("https_proxy_test"))
+			Expect(len(envVars)).To(Equal(0))
+		})
 
-			// Kinda dumb test if they are all empty string
+		It("creates upper and lower case environment variables with the same value", func() {
+			os.Setenv("HTTPS_PROXY", "https_proxy_test")
+			os.Setenv("HTTP_PROXY", "http_proxy_test")
+			os.Setenv("NO_PROXY", "no_proxy_test")
+			envVars := ReadProxyVarsFromEnv()
+
 			for _, envName := range ProxyEnvNames {
 				upperValue, err := checkValueFromEnvObj(envName, envVars)
 				Expect(err).To(BeNil())
@@ -60,6 +61,11 @@ var _ = Describe("Retrieving", func() {
 				Expect(err).To(BeNil())
 				Expect(upperValue).To(Equal(lowerValue))
 			}
+		})
+		AfterEach(func() {
+			_ = os.Unsetenv("HTTPS_PROXY")
+			_ = os.Unsetenv("HTTP_PROXY")
+			_ = os.Unsetenv("NO_PROXY")
 		})
 	})
 })

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,0 +1,65 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func checkValueFromEnvObj(name string, envVars []corev1.EnvVar) (string, error) {
+	for i := range envVars {
+		if envVars[i].Name == name {
+			return envVars[i].Value, nil
+		}
+	}
+	return "", errors.New("empty name")
+
+}
+
+var _ = Describe("Retrieving", func() {
+	Describe("proxy environment variables", func() {
+		// TODO(asmacdo) seems like a bad idea to mess with the env
+		BeforeEach(func() {
+			os.Setenv("HTTPS_PROXY", "https_proxy_test")
+			// 	os.Setenv("HTTP_PROXY", "http_proxy_test")
+			// 	os.Setenv("NO_PROXY", "no_proxy_test")
+		})
+		It("returns a slice of environment variables", func() {
+			envVars := ReadProxyVarsFromEnv()
+			Expect(len(envVars)).To(Equal(6))
+		})
+		It("creates upper and lower case environment variables with the same value", func() {
+			envVars := ReadProxyVarsFromEnv()
+			// dumb, err := checkValueFromEnvObj("HTTPS_PROXY", envVars)
+			// Expect(err).To(BeNil())
+			// Expect(dumb).To(Equal("https_proxy_test"))
+
+			// Kinda dumb test if they are all empty string
+			for _, envName := range ProxyEnvNames {
+				upperValue, err := checkValueFromEnvObj(envName, envVars)
+				Expect(err).To(BeNil())
+				lowerValue, err := checkValueFromEnvObj(strings.ToLower(envName), envVars)
+				Expect(err).To(BeNil())
+				Expect(upperValue).To(Equal(lowerValue))
+			}
+		})
+	})
+})


### PR DESCRIPTION
Signed-off-by: austin <austin@redhat.com>

**Description of the change:**
Adds a helper function to retrieve proxy-related environment variables.

**Motivation for the change:**
As a best practice, operators should be configurable (via the environment variables set on the operator itself) to set up operands that use a network proxy. 
