### PR TITLE
Remove locks for Pods in "Shutdown" status

### DIFF
--- a/leader/leader.go
+++ b/leader/leader.go
@@ -229,7 +229,7 @@ func myOwnerRef(ctx context.Context, client crclient.Client, ns string) (*metav1
 
 func isPodEvicted(pod corev1.Pod) bool {
 	podFailed := pod.Status.Phase == corev1.PodFailed
-	podEvicted := pod.Status.Reason == "Evicted"
+	podEvicted := pod.Status.Reason == "Evicted" || pod.Status.Reason == "Shutdown"
 	return podFailed && podEvicted
 }
 


### PR DESCRIPTION
Kubernetes introduced ["Graceful Node Shutdown"](https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown) as an Alpha feature in 1.20. Pods that are evicted by this mechanism have their status.reason attribute set to "Shutdown". This commit extends the garbage collection so that locks for Pods in the "Shutdown" state are also released.

Deadlocks caused by Pods in "shutdown" state still holding leader locks were observed on a live GKE Cluster with preemtible nodes.

This might also fix #73.
