### PR TITLE
Closes #99: Make logging configurable.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,4 @@ jobs:
         fetch-depth: 0
 
     - name: Run go-apidiff
-      uses: joelanford/go-apidiff@master
+      uses: joelanford/go-apidiff@main

--- a/prune/maxage.go
+++ b/prune/maxage.go
@@ -22,8 +22,9 @@ import (
 // maxAge looks for and prunes resources, currently jobs and pods,
 // that exceed a user specified age (e.g. 3d), resources to be removed
 // are returned
-func pruneByMaxAge(_ context.Context, config Config, resources []ResourceInfo) (resourcesToRemove []ResourceInfo, err error) {
-	config.log.V(1).Info("maxAge running", "setting", config.Strategy.MaxAgeSetting)
+func pruneByMaxAge(ctx context.Context, config Config, resources []ResourceInfo) (resourcesToRemove []ResourceInfo, err error) {
+	log := Logger(ctx, config)
+	log.V(1).Info("maxAge running", "setting", config.Strategy.MaxAgeSetting)
 
 	maxAgeDuration, e := time.ParseDuration(config.Strategy.MaxAgeSetting)
 	if e != nil {
@@ -33,9 +34,9 @@ func pruneByMaxAge(_ context.Context, config Config, resources []ResourceInfo) (
 	maxAgeTime := time.Now().Add(-maxAgeDuration)
 
 	for i := 0; i < len(resources); i++ {
-		config.log.V(1).Info("age of pod ", "age", time.Since(resources[i].StartTime), "maxage", maxAgeTime)
+		log.V(1).Info("age of pod ", "age", time.Since(resources[i].StartTime), "maxage", maxAgeTime)
 		if resources[i].StartTime.Before(maxAgeTime) {
-			config.log.V(1).Info("pruning ", "kind", resources[i].GVK, "name", resources[i].Name)
+			log.V(1).Info("pruning ", "kind", resources[i].GVK, "name", resources[i].Name)
 
 			resourcesToRemove = append(resourcesToRemove, resources[i])
 		}

--- a/prune/maxcount.go
+++ b/prune/maxcount.go
@@ -23,8 +23,9 @@ import (
 // pruneByMaxCount looks for and prunes resources, currently jobs and pods,
 // that exceed a user specified count (e.g. 3), the oldest resources
 // are pruned, resources to remove are returned
-func pruneByMaxCount(_ context.Context, config Config, resources []ResourceInfo) (resourcesToRemove []ResourceInfo, err error) {
-	config.log.V(1).Info("pruneByMaxCount running ", "max count", config.Strategy.MaxCountSetting, "resource count", len(resources))
+func pruneByMaxCount(ctx context.Context, config Config, resources []ResourceInfo) (resourcesToRemove []ResourceInfo, err error) {
+	log := Logger(ctx, config)
+	log.V(1).Info("pruneByMaxCount running ", "max count", config.Strategy.MaxCountSetting, "resource count", len(resources))
 	if config.Strategy.MaxCountSetting < 0 {
 		return resourcesToRemove, fmt.Errorf("max count setting less than zero")
 	}
@@ -32,7 +33,7 @@ func pruneByMaxCount(_ context.Context, config Config, resources []ResourceInfo)
 	if len(resources) > config.Strategy.MaxCountSetting {
 		removeCount := len(resources) - config.Strategy.MaxCountSetting
 		for i := len(resources) - 1; i >= 0; i-- {
-			config.log.V(1).Info("pruning pod ", "pod name", resources[i].Name, "age", time.Since(resources[i].StartTime))
+			log.V(1).Info("pruning pod ", "pod name", resources[i].Name, "age", time.Since(resources[i].StartTime))
 
 			resourcesToRemove = append(resourcesToRemove, resources[i])
 

--- a/prune/remove.go
+++ b/prune/remove.go
@@ -31,7 +31,7 @@ func (config Config) removeResources(ctx context.Context, resources []ResourceIn
 		r := resources[i]
 
 		if config.PreDeleteHook != nil {
-			err = config.PreDeleteHook(config, r)
+			err = config.PreDeleteHook(ctx, config, r)
 			if err != nil {
 				return err
 			}

--- a/prune/resource_test.go
+++ b/prune/resource_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Prune", func() {
 			client = testclient.NewSimpleClientset()
 			ctx = context.Background()
 			cfg = Config{
-				log:           logf.Log.WithName("prune"),
+				Log:           logf.Log.WithName("prune"),
 				DryRun:        false,
 				Clientset:     client,
 				LabelSelector: "app=churro",
@@ -98,7 +98,7 @@ var _ = Describe("Prune", func() {
 		)
 		BeforeEach(func() {
 			cfg = Config{}
-			cfg.log = logf.Log.WithName("prune")
+			cfg.Log = logf.Log.WithName("prune")
 			ctx = context.Background()
 		})
 		It("should return an error when LabelSelector is not set", func() {
@@ -130,7 +130,7 @@ var _ = Describe("Prune", func() {
 			ctx = context.Background()
 			jobcfg = Config{
 				DryRun:        false,
-				log:           logf.Log.WithName("prune"),
+				Log:           logf.Log.WithName("prune"),
 				Clientset:     jobclient,
 				LabelSelector: "app=churro",
 				Resources: []schema.GroupVersionKind{
@@ -318,8 +318,9 @@ func createTestPods(client kubernetes.Interface) (err error) {
 	return nil
 }
 
-func myhook(cfg Config, x ResourceInfo) error {
-	fmt.Println("myhook is called ")
+func myhook(ctx context.Context, cfg Config, x ResourceInfo) error {
+	log := Logger(ctx, cfg)
+	log.V(1).Info("myhook is called")
 	return nil
 }
 
@@ -327,8 +328,9 @@ func myhook(cfg Config, x ResourceInfo) error {
 // example, the strategy doesn't really do another other than count
 // the number of resources, returning a list of resources to delete in
 // this case zero.
-func myStrategy(cfg Config, resources []ResourceInfo) (resourcesToRemove []ResourceInfo, err error) {
-	fmt.Printf("myStrategy is called with resources %v config %v\n", resources, cfg)
+func myStrategy(ctx context.Context, cfg Config, resources []ResourceInfo) (resourcesToRemove []ResourceInfo, err error) {
+	log := Logger(ctx, cfg)
+	log.V(1).Info("myStrategy is called", "resources", resources, "config", cfg)
 	if len(resources) != 3 {
 		return resourcesToRemove, fmt.Errorf("count of resources did not equal our expectation")
 	}


### PR DESCRIPTION
**Description of the change:**

Closes #99
This pull request aligns the logging configuration in the prune feature with what is done in the rest of the library. It declares a package level variable for a logger. The logger is retrieved from the controller-runtime library, which is leveraging logr.

**Motivation for the change:**

The current prune implementation could not be used outside of the prune package as the log field of the Config struct was unexported.

A pull request for amending the documentation will follow.
