### PR TITLE
WIP: add reference implementation of suggested operator health metric

### DIFF
--- a/metrics/health.go
+++ b/metrics/health.go
@@ -1,0 +1,128 @@
+package metrics
+
+import (
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type OperatorHealth struct {
+	// operatorName is the name of the operator.
+	operatorName string
+
+	healthy   prometheus.Gauge
+	degraded  prometheus.Gauge
+	unhealthy prometheus.Gauge
+	unknown   prometheus.Gauge
+}
+
+func NewOperatorHealth(operatorName string) *OperatorHealth {
+	healthy := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "operator_lib",
+		Name:      "operator_healthy",
+		Help:      "Whether the operator is healthy. Value 1 means healthy, 0 means not healthy.",
+		ConstLabels: map[string]string{
+			"operator_name": operatorName,
+		},
+	})
+
+	degraded := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "operator_lib",
+		Name:      "operator_degraded",
+		Help:      "Whether the operator is degraded. Value 1 means degraded, 0 means not degraded.",
+		ConstLabels: map[string]string{
+			"operator_name": operatorName,
+		},
+	})
+
+	unhealthy := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "operator_lib",
+		Name:      "operator_unhealthy",
+		Help:      "Whether the operator is unhealthy. Value 1 means unhealthy, 0 means not unhealthy.",
+		ConstLabels: map[string]string{
+			"operator_name": operatorName,
+		},
+	})
+
+	unknown := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "operator_lib",
+		Name:      "operator_health_unknown",
+		Help:      "Whether the operator health is unknown. Value 1 means unknown, 0 means not unknown.",
+		ConstLabels: map[string]string{
+			"operator_name": operatorName,
+		},
+	})
+
+	m := &OperatorHealth{
+		operatorName: operatorName,
+		healthy:      healthy,
+		degraded:     degraded,
+		unhealthy:    unhealthy,
+		unknown:      unknown,
+	}
+	m.MustSet(OperatorHealthUnknown)
+	return m
+}
+
+func (m *OperatorHealth) Register(registry prometheus.Registerer) error {
+	for _, v := range []prometheus.Gauge{m.healthy, m.degraded, m.unhealthy, m.unknown} {
+		if err := registry.Register(v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *OperatorHealth) Collect(ch chan<- prometheus.Metric) {
+	for _, v := range []prometheus.Collector{m.healthy, m.degraded, m.unhealthy, m.unknown} {
+		v.Collect(ch)
+	}
+}
+
+func (m *OperatorHealth) Describe(ch chan<- *prometheus.Desc) {
+	for _, v := range []prometheus.Collector{m.healthy, m.degraded, m.unhealthy, m.unknown} {
+		v.Describe(ch)
+	}
+}
+
+type OperatorHealthState string
+
+const (
+	OperatorHealthHealthy   OperatorHealthState = "healthy"
+	OperatorHealthDegraded  OperatorHealthState = "degraded"
+	OperatorHealthUnhealthy OperatorHealthState = "unhealthy"
+	OperatorHealthUnknown   OperatorHealthState = "unknown"
+)
+
+func (m *OperatorHealth) Set(status OperatorHealthState) error {
+	switch status {
+	case OperatorHealthHealthy:
+		m.healthy.Set(1)
+		m.degraded.Set(0)
+		m.unhealthy.Set(0)
+		m.unknown.Set(0)
+	case OperatorHealthDegraded:
+		m.healthy.Set(0)
+		m.degraded.Set(1)
+		m.unhealthy.Set(0)
+		m.unknown.Set(0)
+	case OperatorHealthUnhealthy:
+		m.healthy.Set(0)
+		m.degraded.Set(0)
+		m.unhealthy.Set(1)
+		m.unknown.Set(0)
+	case OperatorHealthUnknown:
+		m.healthy.Set(0)
+		m.degraded.Set(0)
+		m.unhealthy.Set(0)
+		m.unknown.Set(1)
+	default:
+		return fmt.Errorf("unknown operator health status %q", status)
+	}
+	return nil
+}
+
+func (m *OperatorHealth) MustSet(status OperatorHealthState) {
+	if err := m.Set(status); err != nil {
+		panic(err)
+	}
+}

--- a/metrics/health_test.go
+++ b/metrics/health_test.go
@@ -1,0 +1,135 @@
+package metrics_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/operator-lib/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"strings"
+)
+
+var _ = Describe("OperatorHealth", func() {
+	Context("NewOperatorHealth", func() {
+		It("should create a new OperatorHealth", func() {
+			m := metrics.NewOperatorHealth("test-operator")
+			Expect(testutil.CollectAndCompare(m, strings.NewReader(expectedUnknown),
+				"operator_lib_operator_healthy",
+				"operator_lib_operator_degraded",
+				"operator_lib_operator_unhealthy",
+				"operator_lib_operator_health_unknown")).To(Succeed())
+		})
+	})
+
+	Context("Register", func() {
+		It("should register the OperatorHealth with the provided registry", func() {
+			reg := prometheus.NewRegistry()
+			m := metrics.NewOperatorHealth("test-operator")
+			err := m.Register(reg)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(testutil.CollectAndCompare(m, strings.NewReader(expectedUnknown),
+				"operator_lib_operator_healthy",
+				"operator_lib_operator_degraded",
+				"operator_lib_operator_unhealthy",
+				"operator_lib_operator_health_unknown")).To(Succeed())
+		})
+	})
+
+	Context("Set", func() {
+		var m *metrics.OperatorHealth
+		BeforeEach(func() {
+			m = metrics.NewOperatorHealth("test-operator")
+		})
+
+		It("should set the operator health metric to healthy", func() {
+			Expect(m.Set(metrics.OperatorHealthHealthy)).To(Succeed())
+			Expect(testutil.CollectAndCompare(m, strings.NewReader(expectedHealthy),
+				"operator_lib_operator_healthy",
+				"operator_lib_operator_degraded",
+				"operator_lib_operator_unhealthy",
+				"operator_lib_operator_health_unknown")).To(Succeed())
+		})
+		It("should set the operator health metric to degraded", func() {
+			Expect(m.Set(metrics.OperatorHealthDegraded)).To(Succeed())
+			Expect(testutil.CollectAndCompare(m, strings.NewReader(expectedDegraded),
+				"operator_lib_operator_healthy",
+				"operator_lib_operator_degraded",
+				"operator_lib_operator_unhealthy",
+				"operator_lib_operator_health_unknown")).To(Succeed())
+		})
+		It("should set the operator health metric to unhealthy", func() {
+			Expect(m.Set(metrics.OperatorHealthUnhealthy)).To(Succeed())
+			Expect(testutil.CollectAndCompare(m, strings.NewReader(expectedUnhealthy),
+				"operator_lib_operator_healthy",
+				"operator_lib_operator_degraded",
+				"operator_lib_operator_unhealthy",
+				"operator_lib_operator_health_unknown")).To(Succeed())
+		})
+		It("should set the operator health metric to unknown", func() {
+			Expect(m.Set(metrics.OperatorHealthUnknown)).To(Succeed())
+			Expect(testutil.CollectAndCompare(m, strings.NewReader(expectedUnknown),
+				"operator_lib_operator_healthy",
+				"operator_lib_operator_degraded",
+				"operator_lib_operator_unhealthy",
+				"operator_lib_operator_health_unknown")).To(Succeed())
+		})
+	})
+})
+
+var (
+	expectedHealthy = `# HELP operator_lib_operator_healthy Whether the operator is healthy. Value 1 means healthy, 0 means not healthy.
+# TYPE operator_lib_operator_healthy gauge
+operator_lib_operator_healthy{operator_name="test-operator"} 1
+# HELP operator_lib_operator_degraded Whether the operator is degraded. Value 1 means degraded, 0 means not degraded.
+# TYPE operator_lib_operator_degraded gauge
+operator_lib_operator_degraded{operator_name="test-operator"} 0
+# HELP operator_lib_operator_unhealthy Whether the operator is unhealthy. Value 1 means unhealthy, 0 means not unhealthy.
+# TYPE operator_lib_operator_unhealthy gauge
+operator_lib_operator_unhealthy{operator_name="test-operator"} 0
+# HELP operator_lib_operator_health_unknown Whether the operator health is unknown. Value 1 means unknown, 0 means not unknown.
+# TYPE operator_lib_operator_health_unknown gauge
+operator_lib_operator_health_unknown{operator_name="test-operator"} 0
+`
+	expectedDegraded = `# HELP operator_lib_operator_healthy Whether the operator is healthy. Value 1 means healthy, 0 means not healthy.
+# TYPE operator_lib_operator_healthy gauge
+operator_lib_operator_healthy{operator_name="test-operator"} 0
+# HELP operator_lib_operator_degraded Whether the operator is degraded. Value 1 means degraded, 0 means not degraded.
+# TYPE operator_lib_operator_degraded gauge
+operator_lib_operator_degraded{operator_name="test-operator"} 1
+# HELP operator_lib_operator_unhealthy Whether the operator is unhealthy. Value 1 means unhealthy, 0 means not unhealthy.
+# TYPE operator_lib_operator_unhealthy gauge
+operator_lib_operator_unhealthy{operator_name="test-operator"} 0
+# HELP operator_lib_operator_health_unknown Whether the operator health is unknown. Value 1 means unknown, 0 means not unknown.
+# TYPE operator_lib_operator_health_unknown gauge
+operator_lib_operator_health_unknown{operator_name="test-operator"} 0
+`
+
+	expectedUnhealthy = `# HELP operator_lib_operator_healthy Whether the operator is healthy. Value 1 means healthy, 0 means not healthy.
+# TYPE operator_lib_operator_healthy gauge
+operator_lib_operator_healthy{operator_name="test-operator"} 0
+# HELP operator_lib_operator_degraded Whether the operator is degraded. Value 1 means degraded, 0 means not degraded.
+# TYPE operator_lib_operator_degraded gauge
+operator_lib_operator_degraded{operator_name="test-operator"} 0
+# HELP operator_lib_operator_unhealthy Whether the operator is unhealthy. Value 1 means unhealthy, 0 means not unhealthy.
+# TYPE operator_lib_operator_unhealthy gauge
+operator_lib_operator_unhealthy{operator_name="test-operator"} 1
+# HELP operator_lib_operator_health_unknown Whether the operator health is unknown. Value 1 means unknown, 0 means not unknown.
+# TYPE operator_lib_operator_health_unknown gauge
+operator_lib_operator_health_unknown{operator_name="test-operator"} 0
+`
+
+	expectedUnknown = `# HELP operator_lib_operator_healthy Whether the operator is healthy. Value 1 means healthy, 0 means not healthy.
+# TYPE operator_lib_operator_healthy gauge
+operator_lib_operator_healthy{operator_name="test-operator"} 0
+# HELP operator_lib_operator_degraded Whether the operator is degraded. Value 1 means degraded, 0 means not degraded.
+# TYPE operator_lib_operator_degraded gauge
+operator_lib_operator_degraded{operator_name="test-operator"} 0
+# HELP operator_lib_operator_unhealthy Whether the operator is unhealthy. Value 1 means unhealthy, 0 means not unhealthy.
+# TYPE operator_lib_operator_unhealthy gauge
+operator_lib_operator_unhealthy{operator_name="test-operator"} 0
+# HELP operator_lib_operator_health_unknown Whether the operator health is unknown. Value 1 means unknown, 0 means not unknown.
+# TYPE operator_lib_operator_health_unknown gauge
+operator_lib_operator_health_unknown{operator_name="test-operator"} 1
+`
+)

--- a/metrics/suite_test.go
+++ b/metrics/suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Suite")
+}


### PR DESCRIPTION
<!--

Welcome to the Operator Lib! Before contributing, make sure to:

- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Add a reference implementation of a potential recommended operator health metric.

**Motivation for the change:**
To provide operator authors with a library to help them define an operator health metric in their operators such that cluster admins can consume operator health information via prometheus in a consistent way across a fleet of operators.


