### PR TITLE
Bump golangci-lint to 1.51.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         go-version-file: "go.mod"
     - uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.49
+        version: v1.51
         args: --timeout 5m
 
   go-apidiff:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean: ## Clean up your working environment
 	@rm -f cover.out
 
 GOLANGCI_LINT=./bin/golangci-lint
-GOLANGCI_LINT_VER=1.49.0
+GOLANGCI_LINT_VER=1.51.0
 golangci-lint:
 ifneq ($(GOLANGCI_LINT_VER), $(shell $(GOLANGCI_LINT) version 2>&1 | cut -d" " -f4))
 	@{ \


### PR DESCRIPTION
<!--

Welcome to the Operator Lib! Before contributing, make sure to:

- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Bump golangci-lint to 1.51.0 

**Motivation for the change:**
golangci-lint 1.51.0+ is needed to be compatible with go 1.20

