### PR TITLE
Fix codecov-action params

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,10 @@ jobs:
         go-version-file: "go.mod"
     - run: make test
     - uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
+        disable_search: true
         files: cover.out
-        functionalities: fixes
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description of the change:**

* `functionalities` param is no longer exist. It was used to enable file fixes to ignore common lines from coverage. This feature is now seems to be on by default.

* Adding `disable_search` because we do not need for the codecov action to search for coverage files: we explicitly provide files.

**Motivation for the change:**

Fixing codecov config
