### PR TITLE
fix bingo-upgrade target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ tidy: ## Tidy go dependencies
 
 .PHONY: bingo-upgrade
 bingo-upgrade: $(BINGO) #EXHELP Upgrade tools
-	@for pkg in $$($(BINGO) list | awk '{ print $$1 }' | tail -n +3); do \
-		echo "Upgrading $$pkg to latest..."; \
+	@for pkg in $$($(BINGO) list | awk '{ print $$3 }' | tail -n +3 | sed 's/@.*//'); do \
+		echo -e "Upgrading \033[35m$$pkg\033[0m to latest..."; \
 		$(BINGO) get "$$pkg@latest"; \
 	done
 


### PR DESCRIPTION
# Description

The current bingo-upgrade make target can choke on bingo dependencies that require the whole path to the executable. For instance, golangci-lint needs to be installed with bingo as follows:

```
bingo get github.com/golangci/golangci-lint/cmd/golangci-lint
```

as opposed to:

```
bingo get github.com/golangci/golangci-lint
```

The update makes use of the 3rd column of the bingo list command:

```
$ bingo list
Name            Binary Name                                             Package @ Version                                                                       Build EnvVars   Build Flags
----            -----------                                             -----------------                                                                       -------------   -----------
bingo           bingo-v0.9.0                                            github.com/bwplotka/bingo@v0.9.0                                                                        
controller-gen  controller-gen-v0.16.1                                  sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.1                                                 
crd-diff        crd-diff-v0.1.0                                         github.com/everettraven/crd-diff@v0.1.0                                                                 
crd-ref-docs    crd-ref-docs-v0.1.0                                     github.com/elastic/crd-ref-docs@v0.1.0                                                                  
golangci-lint   golangci-lint-v1.61.0                                   github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0                                             
goreleaser      goreleaser-v1.26.2                                      github.com/goreleaser/goreleaser@v1.26.2                                                                
kind            kind-v0.24.0                                            sigs.k8s.io/kind@v0.24.0                                                                                
kustomize       kustomize-v4.5.7                                        sigs.k8s.io/kustomize/kustomize/v4@v4.5.7                                                               
operator-sdk    operator-sdk-v1.36.1                                    github.com/operator-framework/operator-sdk/cmd/operator-sdk@v1.36.1                                     -ldflags=-X=github.com/operator-framework/operator-sdk/internal/version.Version=v1.34.1
opm             opm-v1.46.0                                             github.com/operator-framework/operator-registry/cmd/opm@v1.46.0                                         
setup-envtest   setup-envtest-v0.0.0-20240820183333-e6c3d139d2b6        sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240820183333-e6c3d139d2b6  
```

And uses sed to strip everything after (and including) the `@`.

I've tested this manually and it worked for every tool.

## Reviewer Checklist

- [ ] API Go Documentation
- [ ] Tests: Unit Tests (and E2E Tests, if appropriate)
- [ ] Comprehensive Commit Messages
- [ ] Links to related GitHub Issue(s)
