### PR TITLE
:seedling: Use make lint for GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version-file: "go.mod"
-    - uses: golangci/golangci-lint-action@v6
-      with:
-        version: v1.63.4
-        args: --timeout 5m
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - run: make lint
 
   go-apidiff:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
**Description of the change:**

Moves lint check to use `make lint`

**Motivation for the change:**

#220 is failing due to lint issues. `make lint` succeeds and is what we give developers to use. We should probably use the same methodology also because it help us having to keep the golandci-lint versions between the GHA and bingo in sync.


